### PR TITLE
fix the path issue of native extension

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -15,7 +15,9 @@ if RUBY_ENGINE == 'jruby'
   task :default => :test
 else
   require 'rake/extensiontask'
-  Rake::ExtensionTask.new('xorcist', gemspec)
+  Rake::ExtensionTask.new('xorcist', gemspec) do |ext|
+    ext.lib_dir = "lib/xorcist"
+  end
   task :default => [:compile, :test]
 end
 

--- a/ext/xorcist/extconf.rb
+++ b/ext/xorcist/extconf.rb
@@ -1,4 +1,4 @@
 require 'mkmf'
 extension_name = 'xorcist'
 dir_config(extension_name)
-create_makefile(extension_name)
+create_makefile('xorcist/xorcist')

--- a/lib/xorcist.rb
+++ b/lib/xorcist.rb
@@ -4,7 +4,7 @@ if RUBY_ENGINE == 'jruby'
   require 'jruby'
   require File.expand_path('../xorcist.jar', __FILE__)
 else
-  require File.expand_path('../xorcist.so', __FILE__)
+  require 'xorcist/xorcist'
 end
 
 module Xorcist


### PR DESCRIPTION
A normal `bundle install` created 2 xorcist.so files.
```
vendor/bundle/ruby/2.3/extensions/x86_64-linux/2.3/xorcist-1.0.1/xorcist.so
vendor/bundle/ruby/2.3/gems/xorcist-1.0.1/ext/xorcist/xorcist.so
```
While the built gem file contains only this one.
```
vendor/bundle/ruby/2.3/gems/xorcist-1.0.1/ext/xorcist/xorcist.so
```
Try to fix the xorcist.so not found issue in case installing xorcist locally from a packaged gem file.