### PR TITLE
Fix deprecation of include in refinements in Ruby 3.1

### DIFF
--- a/lib/xorcist/refinements.rb
+++ b/lib/xorcist/refinements.rb
@@ -3,7 +3,11 @@ require 'xorcist/string_methods'
 module Xorcist
   module Refinements
     refine String do
-      include Xorcist::StringMethods
+      if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("3.1.0")
+        import_methods Xorcist::StringMethods
+      else
+        include Xorcist::StringMethods
+      end
     end
   end
 end

--- a/xorcist.gemspec
+++ b/xorcist.gemspec
@@ -31,6 +31,6 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'minitest', '~> 5.7'
-  spec.add_development_dependency 'rake', '~> 12.3.3'
-  spec.add_development_dependency 'rake-compiler', '~> 0.9.5'
+  spec.add_development_dependency 'rake'
+  spec.add_development_dependency 'rake-compiler'
 end


### PR DESCRIPTION
Including modules in refinements was deprecated in Ruby 3.1 and removed in Ruby 3.2 (see ticket https://bugs.ruby-lang.org/issues/17429). It has been replaced with import_methods in Ruby 3.1.